### PR TITLE
Resolve command line option propagation more elegantly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: ci 
+on:
+  push:
+    branches:
+      - master 
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install mkdocs-material 
+      - run: cd docs_user; mkdocs gh-deploy --force

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(worker_ng LANGUAGES CXX)
 set(worker_ng_NAME "worker_ng")
 set(worker_ng_VERSION_MAJOR 1)
 set(worker_ng_VERSION_MINOR 0)
-set(worker_ng_VERSION_PATCH 10)
+set(worker_ng_VERSION_PATCH 11)
 
 # define source target
 add_subdirectory(src)

--- a/conf/pbs_config.conf
+++ b/conf/pbs_config.conf
@@ -8,7 +8,7 @@ env_var_exprs = '^VSC_'
 [scheduler]
 name = PBS torque
 submit_command = qsub
-het_prefix =
+het_group_sep =
 jobid_var_name = PBS_JOBID
 arrayid_var_name = PBS_ARRAYID
 env_var_exprs = '^PBS_'

--- a/conf/slurm_config.conf
+++ b/conf/slurm_config.conf
@@ -8,7 +8,7 @@ env_var_exprs = '^VSC_'
 [scheduler]
 name = Slurm
 submit_command = sbatch
-het_prefix = :
+het_group_sep = :
 jobid_var_name = SLURM_JOB_ID
 arrayid_var_name = SLURM_ARRAY_TASK_ID
 env_var_exprs = '^SLURM_'

--- a/conf/slurm_jobscript.tmpl
+++ b/conf/slurm_jobscript.tmpl
@@ -55,7 +55,8 @@ then
 fi
 
 # start the server
-srun --exclusive --nodes=1 --ntasks=1 --cpus-per-task=1 \
+srun --exclusive --het-group=1 --nodes=1 --ntasks=1 --cpus-per-task=1 \
+    --partition=$SLURM_JOB_PARTITION_HET_GROUP_1 \
     "${{worker_server_exec}}" \
         {server_log_opt} \
         {port_opt} \
@@ -86,11 +87,11 @@ server=$(cut -d ' ' -f 2 "$SERVER_INFO")
 export OMP_PROC_BIND=true
 export OMP_PLACES=cores
 
-for (( client_id=1; client_id <= $SLURM_NTASKS_HET_GROUP_1; client_id++ ))
+for (( client_id=1; client_id <= $SLURM_NTASKS_HET_GROUP_0; client_id++ ))
 do
-    srun --exclusive --het-group=1 \
-        --ntasks=1 --nodes=1 --cpus-per-task=$SLURM_CPUS_PER_TASK_HET_GROUP_1 \
-        --partition=$SLURM_JOB_PARTITION_HET_GROUP_1 \
+    srun --exclusive --het-group=0 \
+        --ntasks=1 --nodes=1 --cpus-per-task=$SLURM_CPUS_PER_TASK_HET_GROUP_0 \
+        --partition=$SLURM_JOB_PARTITION_HET_GROUP_0 \
         --threads-per-core=1 \
             "${{worker_client_exec}}" \
                 --server "$server" --uuid "$uuid" {client_log_prefix_opt} \

--- a/docs_user/docs/multithreading.md
+++ b/docs_user/docs/multithreading.md
@@ -5,6 +5,6 @@ can simply be specified by using the `--cpus-per-task` option, similar
 to a regular Slurm job.
 
 If you need to know the number of threads in your Slurm job script,
-you can use the `SLURM_CPUS_PER_TASK_HET_GROUP_1` environment variable.
+you can use the `SLURM_CPUS_PER_TASK_HET_GROUP_0` environment variable.
 This variable has to be used, rather than `SLURM_CPUS_PER_TASK`, because
 under the hood, worker-ng uses a heterogeneous job.

--- a/easyconfig/worker-ng-1.0-GCCcore-10.3.eb
+++ b/easyconfig/worker-ng-1.0-GCCcore-10.3.eb
@@ -1,7 +1,7 @@
 easyblock = 'CMakeMake'
 
 name = 'worker-ng'
-version = '1.0.10'
+version = '1.0.11'
 
 # dependencies
 local_cppzmq_version = '4.8.1'

--- a/scripts/worker/slurm/option_parser.py
+++ b/scripts/worker/slurm/option_parser.py
@@ -123,7 +123,7 @@ class SlurmOptionParser:
         args = list()
         shebang = None
         slurm_directives = ''
-        slurm_group1_directives = ''
+        slurm_group0_directives = ''
         script = ''
         parsing_slurm = True
         with open(file_name, 'r') as file:
@@ -134,7 +134,7 @@ class SlurmOptionParser:
                     new_args = shlex.split(line[len(directive_prefix):], comments=True)
                     args.extend(new_args)
                     if self._is_resource_directive_line(new_args):
-                        slurm_group1_directives += line
+                        slurm_group0_directives += line
                     else:
                         slurm_directives += line
                 elif (line.startswith('#') or line.isspace()) and parsing_slurm:
@@ -142,8 +142,8 @@ class SlurmOptionParser:
                 else:
                     parsing_slurm = False
                     script += line
-        slurm_directives += f'{self.default_directive_prefix} --nodes=1 --ntasks=1 --cpus-per-task=1\n'
-        slurm_directives += f'{self.default_directive_prefix} hetjob\n{slurm_group1_directives}'
+        slurm_directives += f'{slurm_group0_directives}'
+        slurm_directives += f'{self.default_directive_prefix} hetjob\n{self.default_directive_prefix} --nodes=1 --ntasks=1 --cpus-per-task=1\n'
         options, _ = self._base_parser.parse_known_args(args)
         return ParseData(options, shebang, slurm_directives, script, None)
 

--- a/scripts/worker/utils.py
+++ b/scripts/worker/utils.py
@@ -175,7 +175,7 @@ def create_jobscript(file_path, parser_result, template_path, config):
         print(template.format(**templ_params), file=jobscript_file)
 
 def submit_job(submit_cmd_path, jobscript_path, parser_result, config, original_cl_options):
-    command = [config['scheduler']['submit_command']] + [f" {config['scheduler']['het_prefix'] "] + original_cl_options + [str(jobscript_path)]
+    command = [config['scheduler']['submit_command']] +  original_cl_options + [str(jobscript_path)]
     command_str = shlex.join(command)
     with open(submit_cmd_path, 'w') as file:
         print(command_str, file=file)


### PR DESCRIPTION
## Summary by Sourcery

Update worker-ng to propagate command line options directly to the submit command.

New Features:
- Allow users to specify the number of CPUs per task using the `--cpus-per-task` option.

Tests:
- Add CI tests.